### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ matrix:
         -   env: TOXENV=py27 LATEST_GIT=1
         -   env: TOXENV=py36
             python: 3.6
+        -   env: TOXENV=py37
+            python: 3.7
+            dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+            sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 before_install:
     - git --version
     - |

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py27,py36
+envlist = py27,py36,py37
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Demonstrates the current workaround for getting Python 3.7 running on Travis CI.