### PR TITLE
Add TextLineCounterBase to easy python3 transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ git-code-debt-generate
 
 
 The simplest way to write your own custom metrics is to extend
-`git_code_debt.metrics.base.SimpleLineCounterBase`
+`git_code_debt.metrics.base.SimpleLineCounterBase`.
 
 
 Here's what the base class looks like
@@ -106,6 +106,21 @@ class Python__init__LineCount(SimpleLineCounterBase):
     def line_matches_metric(self, line, file_diff_stat):
         # All lines in __init__.py match
         return True
+```
+
+An additional class is provided which feeds lines as text
+(`SimpleLineCounterBase` presents them as `bytes`): `TextLineCounterBase`.
+Here is an example metric using that base class:
+
+```python
+from git_code_debt.metrics.base import TextLineCounterBase
+
+
+class XXXLineCount(TextLineCounterBase):
+    """Counts the number of lines which are XXX comments"""
+
+    def text_line_matches_metric(self, line, file_diff_stat):
+        return '# XXX' in line
 ```
 
 More complex metrics can extend `DiffParserBase`

--- a/git_code_debt/metrics/base.py
+++ b/git_code_debt/metrics/base.py
@@ -91,3 +91,14 @@ class SimpleLineCounterBase(DiffParserBase):
         :param FileDiffStat file_diff_stat:
         """
         raise NotImplementedError
+
+
+class TextLineCounterBase(SimpleLineCounterBase):
+    __metric__ = False
+
+    def text_line_matches_metric(self, line, file_diff_stat):
+        raise NotImplementedError
+
+    def line_matches_metric(self, line, file_diff_stat):
+        text = line.decode('UTF-8', 'ignore')
+        return self.text_line_matches_metric(text, file_diff_stat)

--- a/tests/metrics/base_test.py
+++ b/tests/metrics/base_test.py
@@ -6,6 +6,7 @@ from git_code_debt.metric import Metric
 from git_code_debt.metrics.base import DiffParserBase
 from git_code_debt.metrics.base import MetricInfo
 from git_code_debt.metrics.base import SimpleLineCounterBase
+from git_code_debt.metrics.base import TextLineCounterBase
 from git_code_debt.repo_parser import Commit
 
 
@@ -50,3 +51,15 @@ def test_simple_base_counter():
 def test_includes_file_by_default():
     counter = SimpleLineCounterBase()
     assert counter.should_include_file(None)
+
+
+def test_text_line_counter_base():
+    class Counter(TextLineCounterBase):
+        def text_line_matches_metric(self, line, file_diff_stat):
+            return 'foo' in line
+
+    parser = Counter()
+    stats = [FileDiffStat('test.py', [b'hello', b'foo world'], [], 'ignored')]
+
+    metric, = parser.get_metrics_from_stat(Commit.blank, stats)
+    assert metric == Metric('Counter', 1)


### PR DESCRIPTION
since it's a little clunky to work with bytes in `SimpleLineCounterBase`