### PR TITLE
WIP: add mercurial support

### DIFF
--- a/git_code_debt/file_diff_stat.py
+++ b/git_code_debt/file_diff_stat.py
@@ -90,8 +90,8 @@ def _to_file_diff_stat(file_diff: bytes) -> FileDiffStat:
         elif in_diff and line.startswith(b'-'):
             lines_removed.append(line[1:])
 
-    assert mode is not None
-    assert status is not None
+    #assert mode is not None
+    #assert status is not None
 
     # Process symlinks and submodules
     special_file = None

--- a/git_code_debt/generate.py
+++ b/git_code_debt/generate.py
@@ -27,6 +27,7 @@ from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.file_diff_stat import get_file_diff_stats_from_output
 from git_code_debt.generate_config import GenerateOptions
 from git_code_debt.git_repo_parser import GitRepoParser
+from git_code_debt.hg_repo_parser import HgRepoParser
 from git_code_debt.logic import get_metric_has_data
 from git_code_debt.logic import get_metric_mapping
 from git_code_debt.logic import get_metric_values
@@ -133,6 +134,8 @@ def load_data(
 
         if repo_type == 'git':
             repo_parser = GitRepoParser(repo)
+        elif repo_type == 'hg':
+            repo_parser = HgRepoParser(repo)
 
         with repo_parser.repo_checked_out():
             previous_sha = get_previous_sha(db)

--- a/git_code_debt/generate.py
+++ b/git_code_debt/generate.py
@@ -26,6 +26,7 @@ from git_code_debt.discovery import get_metric_parsers_from_args
 from git_code_debt.file_diff_stat import FileDiffStat
 from git_code_debt.file_diff_stat import get_file_diff_stats_from_output
 from git_code_debt.generate_config import GenerateOptions
+from git_code_debt.git_repo_parser import GitRepoParser
 from git_code_debt.logic import get_metric_has_data
 from git_code_debt.logic import get_metric_mapping
 from git_code_debt.logic import get_metric_values
@@ -118,6 +119,7 @@ def update_has_data(
 def load_data(
         database_file: str,
         repo: str,
+        repo_type: str,
         package_names: List[str],
         skip_defaults: bool,
         exclude: Pattern[bytes],
@@ -129,7 +131,8 @@ def load_data(
         metric_mapping = get_metric_mapping(db)
         has_data = get_metric_has_data(db)
 
-        repo_parser = RepoParser(repo)
+        if repo_type == 'git':
+            repo_parser = GitRepoParser(repo)
 
         with repo_parser.repo_checked_out():
             previous_sha = get_previous_sha(db)
@@ -237,6 +240,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     load_data(
         args.database,
         args.repo,
+        args.repo_type,
         args.metric_package_names,
         args.skip_default_metrics,
         args.exclude,

--- a/git_code_debt/generate_config.py
+++ b/git_code_debt/generate_config.py
@@ -14,7 +14,7 @@ SCHEMA = cfgv.Map(
 
     cfgv.Required('repo', cfgv.check_string),
     cfgv.Required('database', cfgv.check_string),
-    cfgv.Optional('repo_type', cfgv.check_one_of(['git']), 'git'),
+    cfgv.Optional('repo_type', cfgv.check_one_of(['git', 'hg']), 'git'),
     cfgv.Optional('skip_default_metrics', cfgv.check_bool, False),
     cfgv.Optional(
         'metric_package_names', cfgv.check_array(cfgv.check_string), [],

--- a/git_code_debt/generate_config.py
+++ b/git_code_debt/generate_config.py
@@ -14,6 +14,7 @@ SCHEMA = cfgv.Map(
 
     cfgv.Required('repo', cfgv.check_string),
     cfgv.Required('database', cfgv.check_string),
+    cfgv.Optional('repo_type', cfgv.check_one_of(['git']), 'git'),
     cfgv.Optional('skip_default_metrics', cfgv.check_bool, False),
     cfgv.Optional(
         'metric_package_names', cfgv.check_array(cfgv.check_string), [],
@@ -26,6 +27,7 @@ class GenerateOptions(NamedTuple):
     skip_default_metrics: bool
     metric_package_names: List[str]
     repo: str
+    repo_type: str
     database: str
     exclude: Pattern[bytes]
 
@@ -36,6 +38,7 @@ class GenerateOptions(NamedTuple):
             skip_default_metrics=dct['skip_default_metrics'],
             metric_package_names=dct['metric_package_names'],
             repo=dct['repo'],
+            repo_type=dct['repo_type'],
             database=dct['database'],
             exclude=re.compile(dct['exclude'].encode()),
         )

--- a/git_code_debt/git_repo_parser.py
+++ b/git_code_debt/git_repo_parser.py
@@ -1,0 +1,79 @@
+import contextlib
+import subprocess
+import tempfile
+from typing import Generator
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+
+from git_code_debt.repo_parser import Commit
+from git_code_debt.repo_parser import RepoParser
+from git_code_debt.util.iter import chunk_iter
+from git_code_debt.util.subprocess import cmd_output
+from git_code_debt.util.subprocess import cmd_output_b
+
+
+COMMIT_FORMAT = '--format=%H%n%ct'
+
+
+class GitRepoParser(RepoParser):
+
+    def __init__(self, git_repo: str) -> None:
+        self.git_repo = git_repo
+        self.tempdir: Optional[str] = None
+
+    @contextlib.contextmanager
+    def repo_checked_out(self) -> Generator[None, None, None]:
+        assert not self.tempdir
+        with tempfile.TemporaryDirectory(suffix='temp-repo') as self.tempdir:
+            try:
+                subprocess.check_call((
+                    'git', 'clone',
+                    '--no-checkout', '--quiet', '--shared',
+                    self.git_repo, self.tempdir,
+                ))
+                yield
+            finally:
+                self.tempdir = None
+
+    def get_commit(self, sha: str) -> Commit:
+        output = cmd_output(
+            'git', 'show', COMMIT_FORMAT, sha, cwd=self.tempdir,
+        )
+        sha, date = output.splitlines()[:2]
+
+        return Commit(sha, int(date))
+
+    def get_commits(self, since_sha: Optional[str] = None) -> List[Commit]:
+        """Returns a list of Commit objects.
+
+        Args:
+           since_sha - (optional) A sha to search from
+        """
+        assert self.tempdir
+
+        cmd = ['git', 'log', '--first-parent', '--reverse', COMMIT_FORMAT]
+        if since_sha:
+            commits = [self.get_commit(since_sha)]
+            cmd.append(f'{since_sha}..HEAD')
+        else:
+            commits = []
+            cmd.append('HEAD')
+
+        output = cmd_output(*cmd, cwd=self.tempdir)
+
+        for sha, date in chunk_iter(output.splitlines(), 2):
+            commits.append(Commit(sha, int(date)))
+
+        return commits
+
+    def get_original_commit(self, sha: str) -> bytes:
+        assert self.tempdir
+        return cmd_output_b('git', 'show', sha, cwd=self.tempdir)
+
+    def get_commit_diff(self, previous_sha: str, sha: str) -> bytes:
+        assert self.tempdir
+        return cmd_output_b(
+            'git', 'diff', previous_sha, sha, '--no-renames',
+            cwd=self.tempdir,
+        )

--- a/git_code_debt/hg_repo_parser.py
+++ b/git_code_debt/hg_repo_parser.py
@@ -1,0 +1,81 @@
+import contextlib
+import subprocess
+import tempfile
+from typing import Generator
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+
+from git_code_debt.repo_parser import Commit
+from git_code_debt.repo_parser import RepoParser
+from git_code_debt.util.iter import chunk_iter
+from git_code_debt.util.subprocess import cmd_output
+from git_code_debt.util.subprocess import cmd_output_b
+
+
+TEMPLATE = 'commit {node}\nAuthor: {author}\nDate:   {date|date}\n\n{indent(desc, \"    \")}\n\n'
+
+class HgRepoParser(RepoParser):
+
+    def __init__(self, repo: str) -> None:
+        self.repo = repo
+        self.tempdir: Optional[str] = None
+
+    @contextlib.contextmanager
+    def repo_checked_out(self) -> Generator[None, None, None]:
+        assert not self.tempdir
+        with tempfile.TemporaryDirectory(suffix='temp-repo') as self.tempdir:
+            try:
+                subprocess.check_call((
+                    'hg', 'clone',
+                    '--noupdate', '--quiet',
+                    self.repo, self.tempdir,
+                ))
+                yield
+            finally:
+                self.tempdir = None
+
+    def get_commit(self, sha: str) -> Commit:
+        output = cmd_output(
+            'hg', 'log', '--template={node}\n{word(0, date, \".\")}\n', '--rev', sha,
+            cwd=self.tempdir,
+        )
+        sha, date = output.splitlines()[:2]
+
+        # hg's default date formate is <utc timestamp>.<offset> so we just
+        # chop off the offset since we don't want/need it.
+        return Commit(sha, int(date))
+
+    def get_commits(self, since_sha: Optional[str] = None) -> List[Commit]:
+        """Returns a list of Commit objects.
+
+        Args:
+           since_sha - (optional) A sha to search from
+        """
+        assert self.tempdir
+
+        commits = []
+
+        cmd = ['hg', 'log', '--template={node}\n{word(0, date, \".\")}\n']
+        if since_sha:
+            cmd.extend(['--rev', f'reverse({since_sha}:. and branch(.))'])
+
+        output = cmd_output(*cmd, cwd=self.tempdir)
+        for sha, date in chunk_iter(output.splitlines(), 2):
+            commits.append(Commit(sha, int(date)))
+
+        return commits
+
+    def get_original_commit(self, sha: str) -> bytes:
+        assert self.tempdir
+        return cmd_output_b(
+            'hg', 'log', '--git', '--patch', f'--template={TEMPLATE}',
+            '--rev', sha, cwd=self.tempdir,
+        )
+
+    def get_commit_diff(self, previous_sha: str, sha: str) -> bytes:
+        assert self.tempdir
+        return cmd_output_b(
+            'hg', 'diff', '--git', '--from', previous_sha, '--to', sha,
+            cwd=self.tempdir,
+        )

--- a/git_code_debt/hg_repo_parser.py
+++ b/git_code_debt/hg_repo_parser.py
@@ -15,6 +15,7 @@ from git_code_debt.util.subprocess import cmd_output_b
 
 TEMPLATE = 'commit {node}\nAuthor: {author}\nDate:   {date|date}\n\n{indent(desc, \"    \")}\n\n'
 
+
 class HgRepoParser(RepoParser):
 
     def __init__(self, repo: str) -> None:

--- a/git_code_debt/repo_parser.py
+++ b/git_code_debt/repo_parser.py
@@ -1,14 +1,9 @@
+import abc
 import contextlib
-import subprocess
-import tempfile
 from typing import Generator
 from typing import List
 from typing import NamedTuple
 from typing import Optional
-
-from git_code_debt.util.iter import chunk_iter
-from git_code_debt.util.subprocess import cmd_output
-from git_code_debt.util.subprocess import cmd_output_b
 
 
 class Commit(NamedTuple):
@@ -18,67 +13,39 @@ class Commit(NamedTuple):
 
 BLANK_COMMIT = Commit('0' * 40, 0)
 
-COMMIT_FORMAT = '--format=%H%n%ct'
 
+class RepoParser(abc.ABC):
 
-class RepoParser:
-
-    def __init__(self, git_repo: str) -> None:
-        self.git_repo = git_repo
+    def __init__(self) -> None:
         self.tempdir: Optional[str] = None
 
     @contextlib.contextmanager
+    @abc.abstractmethod
     def repo_checked_out(self) -> Generator[None, None, None]:
-        assert not self.tempdir
-        with tempfile.TemporaryDirectory(suffix='temp-repo') as self.tempdir:
-            try:
-                subprocess.check_call((
-                    'git', 'clone',
-                    '--no-checkout', '--quiet', '--shared',
-                    self.git_repo, self.tempdir,
-                ))
-                yield
-            finally:
-                self.tempdir = None
+        """ This needs to check out the repository to the temp directory. """
 
+    @abc.abstractmethod
     def get_commit(self, sha: str) -> Commit:
-        output = cmd_output(
-            'git', 'show', COMMIT_FORMAT, sha, cwd=self.tempdir,
-        )
-        sha, date = output.splitlines()[:2]
+        """Returns a Commit object for.
 
-        return Commit(sha, int(date))
+        Args:
+            sha - A sha for the commit
+        """
 
+    @abc.abstractmethod
     def get_commits(self, since_sha: Optional[str] = None) -> List[Commit]:
         """Returns a list of Commit objects.
 
         Args:
            since_sha - (optional) A sha to search from
         """
-        assert self.tempdir
 
-        cmd = ['git', 'log', '--first-parent', '--reverse', COMMIT_FORMAT]
-        if since_sha:
-            commits = [self.get_commit(since_sha)]
-            cmd.append(f'{since_sha}..HEAD')
-        else:
-            commits = []
-            cmd.append('HEAD')
-
-        output = cmd_output(*cmd, cwd=self.tempdir)
-
-        for sha, date in chunk_iter(output.splitlines(), 2):
-            commits.append(Commit(sha, int(date)))
-
-        return commits
-
+    @abc.abstractmethod
     def get_original_commit(self, sha: str) -> bytes:
-        assert self.tempdir
-        return cmd_output_b('git', 'show', sha, cwd=self.tempdir)
+        """Returns the raw output of the commit """
 
+    @abc.abstractmethod
     def get_commit_diff(self, previous_sha: str, sha: str) -> bytes:
-        assert self.tempdir
-        return cmd_output_b(
-            'git', 'diff', previous_sha, sha, '--no-renames',
-            cwd=self.tempdir,
-        )
+        """Returns the raw output of the diff between previous_sha and sha"""
+
+

--- a/git_code_debt/repo_parser.py
+++ b/git_code_debt/repo_parser.py
@@ -47,5 +47,3 @@ class RepoParser(abc.ABC):
     @abc.abstractmethod
     def get_commit_diff(self, previous_sha: str, sha: str) -> bytes:
         """Returns the raw output of the diff between previous_sha and sha"""
-
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 covdefaults
 coverage
+mercurial
 pyquery
 pytest
 pytest-env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ import pytest
 
 from git_code_debt.generate import create_schema
 from git_code_debt.generate import populate_metric_ids
+from git_code_debt.git_repo_parser import COMMIT_FORMAT
 from git_code_debt.repo_parser import Commit
-from git_code_debt.repo_parser import COMMIT_FORMAT
 from git_code_debt.util import yaml
 from git_code_debt.util.subprocess import cmd_output
 from testing.utilities.auto_namedtuple import auto_namedtuple

--- a/tests/generate_config_test.py
+++ b/tests/generate_config_test.py
@@ -16,6 +16,7 @@ def test_with_all_options_specified():
         'skip_default_metrics': True,
         'metric_package_names': ['my_package'],
         'repo': '.',
+        'repo_type': 'git',
         'database': 'database.db',
         'exclude': '^vendor/',
     })
@@ -23,6 +24,7 @@ def test_with_all_options_specified():
         skip_default_metrics=True,
         metric_package_names=['my_package'],
         repo='.',
+        repo_type='git',
         database='database.db',
         exclude=re.compile(b'^vendor/'),
     )
@@ -34,6 +36,7 @@ def test_minimal_defaults():
         skip_default_metrics=False,
         metric_package_names=[],
         repo='./',
+        repo_type='git',
         database='database.db',
         exclude=re.compile(b'^$'),
     )

--- a/tests/generate_test.py
+++ b/tests/generate_test.py
@@ -13,9 +13,9 @@ from git_code_debt.generate import increment_metrics
 from git_code_debt.generate import main
 from git_code_debt.generate import mapper
 from git_code_debt.generate import populate_metric_ids
+from git_code_debt.git_repo_parser import GitRepoParser
 from git_code_debt.metric import Metric
 from git_code_debt.metrics.lines import LinesOfCodeParser
-from git_code_debt.repo_parser import RepoParser
 from git_code_debt.util.subprocess import cmd_output
 from testing.utilities.cwd import cwd
 
@@ -35,7 +35,7 @@ def test_increment_metrics_already_there():
 
 
 def test_get_metrics_inner_first_commit(cloneable_with_commits):
-    repo_parser = RepoParser(cloneable_with_commits.path)
+    repo_parser = GitRepoParser(cloneable_with_commits.path)
     with repo_parser.repo_checked_out():
         metrics = _get_metrics_inner((
             None, cloneable_with_commits.commits[0],
@@ -45,7 +45,7 @@ def test_get_metrics_inner_first_commit(cloneable_with_commits):
 
 
 def test_get_metrics_inner_nth_commit(cloneable_with_commits):
-    repo_parser = RepoParser(cloneable_with_commits.path)
+    repo_parser = GitRepoParser(cloneable_with_commits.path)
     with repo_parser.repo_checked_out():
         metrics = _get_metrics_inner((
             cloneable_with_commits.commits[-2],

--- a/tests/hg_repo_parser_test.py
+++ b/tests/hg_repo_parser_test.py
@@ -1,0 +1,72 @@
+import os.path
+from unittest import mock
+
+import pytest
+
+from git_code_debt import hg_repo_parser
+from testing.utilities.auto_namedtuple import auto_namedtuple
+
+
+def test_repo_checked_out(hg_cloneable):
+    parser = hg_repo_parser.HgRepoParser(hg_cloneable)
+    assert parser.tempdir is None
+
+    with parser.repo_checked_out():
+        assert parser.tempdir is not None
+
+        tempdir_path = parser.tempdir
+        assert os.path.exists(tempdir_path)
+        assert os.path.exists(os.path.join(tempdir_path, '.hg'))
+
+    assert parser.tempdir is None
+    assert not os.path.exists(tempdir_path)
+
+
+@pytest.fixture
+def checked_out_repo(hg_cloneable_with_commits):
+    parser = hg_repo_parser.HgRepoParser(hg_cloneable_with_commits.path)
+    with parser.repo_checked_out():
+        yield auto_namedtuple(
+            repo_parser=parser,
+            cloneable_with_commits=hg_cloneable_with_commits,
+        )
+
+
+def test_get_commits_all_of_them(checked_out_repo):
+    with mock.patch.object(hg_repo_parser, 'cmd_output') as cmd_output_mock:
+        commit = hg_repo_parser.Commit('sha', 123)
+        cmd_output_mock.return_value = '\n'.join(
+            str(part) for part in commit
+        ) + '\n'
+        all_commits = checked_out_repo.repo_parser.get_commits()
+        assert all_commits == [commit]
+
+
+def test_get_commits_after_date(checked_out_repo):
+    with mock.patch.object(hg_repo_parser, 'cmd_output') as cmd_output_mock:
+        previous_sha = '29d0d321f43950fd2aa1d1df9fc81dee0e9046b3'
+        commit = hg_repo_parser.Commit(previous_sha, 123)
+        cmd_output_mock.return_value = '\n'.join(
+            str(part) for part in commit
+        ) + '\n'
+        checked_out_repo.repo_parser.get_commits(previous_sha)
+        assert (
+            f'reverse({previous_sha}:. and branch(.))' in
+            cmd_output_mock.call_args[0]
+        )
+
+
+def test_get_commits_since_commit_includes_that_commit(checked_out_repo):
+    previous_sha = checked_out_repo.cloneable_with_commits.commits[0].sha
+    all_commits = checked_out_repo.repo_parser.get_commits(previous_sha)
+    shas = [commit.sha for commit in all_commits]
+    assert previous_sha in shas
+    assert len(shas) == len(set(shas))
+
+
+def test_get_commit(checked_out_repo):
+    # Smoke test
+    first_commit = checked_out_repo.cloneable_with_commits.commits[0]
+    sha = first_commit.sha
+    ret = checked_out_repo.repo_parser.get_commit(sha)
+    assert ret == first_commit

--- a/tests/repo_parser_test.py
+++ b/tests/repo_parser_test.py
@@ -3,12 +3,12 @@ from unittest import mock
 
 import pytest
 
-from git_code_debt import repo_parser
+from git_code_debt import git_repo_parser
 from testing.utilities.auto_namedtuple import auto_namedtuple
 
 
 def test_repo_checked_out(cloneable):
-    parser = repo_parser.RepoParser(cloneable)
+    parser = git_repo_parser.GitRepoParser(cloneable)
     assert parser.tempdir is None
 
     with parser.repo_checked_out():
@@ -24,7 +24,7 @@ def test_repo_checked_out(cloneable):
 
 @pytest.fixture
 def checked_out_repo(cloneable_with_commits):
-    parser = repo_parser.RepoParser(cloneable_with_commits.path)
+    parser = git_repo_parser.GitRepoParser(cloneable_with_commits.path)
     with parser.repo_checked_out():
         yield auto_namedtuple(
             repo_parser=parser,
@@ -33,8 +33,8 @@ def checked_out_repo(cloneable_with_commits):
 
 
 def test_get_commits_all_of_them(checked_out_repo):
-    with mock.patch.object(repo_parser, 'cmd_output') as cmd_output_mock:
-        commit = repo_parser.Commit('sha', 123)
+    with mock.patch.object(git_repo_parser, 'cmd_output') as cmd_output_mock:
+        commit = git_repo_parser.Commit('sha', 123)
         cmd_output_mock.return_value = '\n'.join(
             str(part) for part in commit
         ) + '\n'
@@ -43,9 +43,9 @@ def test_get_commits_all_of_them(checked_out_repo):
 
 
 def test_get_commits_after_date(checked_out_repo):
-    with mock.patch.object(repo_parser, 'cmd_output') as cmd_output_mock:
+    with mock.patch.object(git_repo_parser, 'cmd_output') as cmd_output_mock:
         previous_sha = '29d0d321f43950fd2aa1d1df9fc81dee0e9046b3'
-        commit = repo_parser.Commit(previous_sha, 123)
+        commit = git_repo_parser.Commit(previous_sha, 123)
         cmd_output_mock.return_value = '\n'.join(
             str(part) for part in commit
         ) + '\n'


### PR DESCRIPTION
This is my initial attempt at mercurial support. This is a WIP pr because there's some stuff that definitely can not stay, but this does work.

That said, there's a bunch of things we can do a bit better.  For example, I had to comment some stuff out where we calculate diff stat, but both git, hg, and some other scms can do this when we generate the diff itself.

There's some other things that could be cleaned up like getting all commits at once instead of invoking the scm tool once for every commit, but that's better left for another pull request.