### PR TITLE
Prevent crash when handling PDF

### DIFF
--- a/git_code_debt/util/subprocess.py
+++ b/git_code_debt/util/subprocess.py
@@ -24,4 +24,4 @@ def cmd_output_b(*cmd: str, **kwargs: Any) -> bytes:
 
 
 def cmd_output(*cmd: str, **kwargs: Any) -> str:
-    return cmd_output_b(*cmd, **kwargs).decode()
+    return cmd_output_b(*cmd, **kwargs).decode('utf-8', 'ignore')


### PR DESCRIPTION
I was getting the following error:
```
python UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 2779: invalid continuation byte
```
When trying git-code-debt was trying to pares a commit with this pdf in it:
[sample.pdf](https://github.com/asottile/git-code-debt/files/10513548/sample.pdf)

Ignoring decode errors fixed it for me, but not sure if there's a better approach here.